### PR TITLE
Feature/disable white space linter

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -218,7 +218,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     ),
     .package(
       url: "https://github.com/apple/swift-syntax.git",
-      branch: "main"
+      revision: "2ae7e2e" // cannot use version 5.9-macros-remove-macrosystem since it is not semver, so the workarround is to link it to a speciffic commit.
     ),
   ]
 } else {

--- a/Package.swift
+++ b/Package.swift
@@ -218,7 +218,7 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     ),
     .package(
       url: "https://github.com/apple/swift-syntax.git",
-      revision: "2ae7e2e" // cannot use version 5.9-macros-remove-macrosystem since it is not semver, so the workarround is to link it to a speciffic commit.
+      revision: "a6cc6ab" // cannot use tags in this repo since it is not semver, so the workarround is to link it to a speciffic commit.
     ),
   ]
 } else {

--- a/Sources/SwiftFormatRules/DeclSyntaxProtocol+Comments.swift
+++ b/Sources/SwiftFormatRules/DeclSyntaxProtocol+Comments.swift
@@ -62,7 +62,7 @@ extension DeclSyntaxProtocol {
       case .newlines(let n), .carriageReturns(let n), .carriageReturnLineFeeds(let n):
         // Only allow for 1 newline between doc line comments, but allow for newlines between the
         // doc comment and the declaration.
-        guard n == 1 || !hasSeenFirstLineComment else { break gatherComments }
+        guard !hasSeenFirstLineComment else { break gatherComments }
       case .spaces, .tabs:
         // Skip all spaces/tabs. They're irrelevant here.
         break


### PR DESCRIPTION
- Set specific swift-syntax version
- Remove need for at least one new line in methods with multiple parameters